### PR TITLE
Usability fixes

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -88,6 +88,26 @@ static retro_environment_t environ_cb = NULL;
 // Utilities
 ///////////////////////////////////////////////////////////
 
+static void InitialiseInputDescriptors(void)
+{
+	struct retro_input_descriptor desc[] = {
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,   "D-Pad Left" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,     "D-Pad Up" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,   "D-Pad Down" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  "D-Pad Right" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,      "B" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,      "A" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      "Shake" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      "C" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Power" },
+		{ 0 },
+	};
+	
+	environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
+}
+
+///////////////////////////////////////////////////////////
+
 static void extract_basename(char *buf, const char *path, size_t size)
 {
 	const char *base = strrchr(path, '/');
@@ -314,15 +334,15 @@ static int PokeMini_LoadMINFileXPLATFORM(size_t size, uint8_t* buffer)
 
 void handlekeyevents()
 {
-	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_START,9);
-	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_UP,10);
-	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_DOWN,11);
-	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_LEFT,4);
-	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_RIGHT,5);
-	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_A,1);
-	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_B,2);
-	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_L,6);
-	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_R,7);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_SELECT,  9);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_UP,     10);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_DOWN,   11);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_LEFT,    4);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_RIGHT,   5);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_A,       1);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_B,       2);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_L,       6);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_R,       7);
 }
 
 // Core functions
@@ -543,6 +563,7 @@ bool retro_load_game(const struct retro_game_info *game)
 	if (!game)
 		return false;
 	
+	InitialiseInputDescriptors();
 	InitialiseCommandLine(game);
 	
 	//add LCDMODE_COLORS option

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -23,15 +23,14 @@
  int PokeMini_LoadMINFile(const char *filename);
  */
 
-
-//pokemini headers
+// pokemini headers
+#include "MinxIO.h"
+#include "PMCommon.h"
 #include "PokeMini.h"
 #include "Hardware.h"
 #include "Joystick.h"
 #include "UI.h"
-//#include "Video_x4.h"
-#include "Video_x3.h"
-#include "PokeMini_BG3.h"
+#include "Video_x4.h"
 
 #define MAKEBTNMAP(btn,pkebtn) JoystickButtonsEvent((pkebtn), input_cb(0/*port*/, RETRO_DEVICE_JOYPAD, 0, (btn)) != 0)
 
@@ -39,9 +38,15 @@
 #define SOUNDBUFFER	2048
 #define PMSOUNDBUFF	(SOUNDBUFFER*2)
 
-uint16_t screenbuff [320*240];
-int PixPitch = 320;//screen->pitch / 2;
-int ScOffP = (24 * 320/*PixPitch*/) + 16;
+// Screen dimension definitions
+#define PM_SCEEN_WIDTH  96
+#define PM_SCEEN_HEIGHT 64
+#define PM_VIDEO_SCALE  4
+#define PM_VIDEO_WIDTH  (PM_SCEEN_WIDTH * PM_VIDEO_SCALE)
+#define PM_VIDEO_HEIGHT (PM_SCEEN_HEIGHT * PM_VIDEO_SCALE)
+
+uint16_t screenbuff [PM_VIDEO_WIDTH * PM_VIDEO_HEIGHT];
+int PixPitch = PM_VIDEO_WIDTH; // screen->pitch / 2;
 
 // Platform menu (REQUIRED >= 0.4.4)
 int UIItems_PlatformC(int index, int reason);
@@ -65,28 +70,6 @@ int UIItems_PlatformC(int index, int reason)
    return 1;
 }
 
-// Load MIN ROM
-int PokeMini_LoadMINFileXPLATFORM(size_t size, uint8_t* buffer)
-{
-   // Check if size is valid
-   if ((size <= 0x2100) || (size > 0x200000))
-      return 0;
-   
-   // Free existing color information
-   PokeMini_FreeColorInfo();
-   
-   // Allocate ROM and set cartridge size
-   if (!PokeMini_NewMIN(size))
-      return 0;
-   
-   // Read content
-   memcpy(PM_ROM,buffer,size);
-   
-   NewMulticart();
-   
-   return 1;
-}
-
 static retro_log_printf_t log_cb = NULL;
 static retro_video_refresh_t video_cb = NULL;
 static retro_input_poll_t poll_cb = NULL;
@@ -95,228 +78,305 @@ static retro_audio_sample_t audio_cb = NULL;
 static retro_audio_sample_batch_t audio_batch_cb = NULL;
 static retro_environment_t environ_cb = NULL;
 
-void handlekeyevents(){
-   MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_START,9);
-   MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_UP,10);
-   MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_DOWN,11);
-   MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_LEFT,4);
-   MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_RIGHT,5);
-   MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_A,1);
-   MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_B,2);
-   MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_L,6);
-   MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_R,7);
+// Utilities
+///////////////////////////////////////////////////////////
+
+// Load MIN ROM
+int PokeMini_LoadMINFileXPLATFORM(size_t size, uint8_t* buffer)
+{
+	// Check if size is valid
+	if ((size <= 0x2100) || (size > 0x200000))
+		return 0;
+	
+	// Free existing color information
+	PokeMini_FreeColorInfo();
+	
+	// Allocate ROM and set cartridge size
+	if (!PokeMini_NewMIN(size))
+		return 0;
+	
+	// Read content
+	memcpy(PM_ROM,buffer,size);
+	
+	NewMulticart();
+	
+	return 1;
 }
+
+///////////////////////////////////////////////////////////
+
+void handlekeyevents()
+{
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_START,9);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_UP,10);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_DOWN,11);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_LEFT,4);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_RIGHT,5);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_A,1);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_B,2);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_L,6);
+	MAKEBTNMAP(RETRO_DEVICE_ID_JOYPAD_R,7);
+}
+
+// Core functions
+///////////////////////////////////////////////////////////
 
 void *retro_get_memory_data(unsigned type)
 {
-   if (type == RETRO_MEMORY_SYSTEM_RAM)
-      return PM_RAM;
-   else
-      return NULL;
+	if (type == RETRO_MEMORY_SYSTEM_RAM)
+		return PM_RAM;
+	else
+		return NULL;
 }
+
+///////////////////////////////////////////////////////////
 
 size_t retro_get_memory_size(unsigned type)
 {
-   if (type == RETRO_MEMORY_SYSTEM_RAM)
-      return 0x2000;
-   else
-      return 0;
+	if (type == RETRO_MEMORY_SYSTEM_RAM)
+		return 0x2000;
+	else
+		return 0;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_set_video_refresh(retro_video_refresh_t cb)
 {
-   video_cb = cb;
+	video_cb = cb;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_set_audio_sample(retro_audio_sample_t cb)
 {
-   audio_cb = cb;
+	audio_cb = cb;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb)
 {
-   audio_batch_cb = cb;
+	audio_batch_cb = cb;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_set_input_poll(retro_input_poll_t cb)
 {
-   poll_cb = cb;
+	poll_cb = cb;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_set_input_state(retro_input_state_t cb)
 {
-   input_cb = cb;
+	input_cb = cb;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_set_environment(retro_environment_t cb)
 {
-   struct retro_log_callback logging;
-   
-   environ_cb = cb;
-   
-   if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &logging))
-      log_cb = logging.log;
-   else
-      log_cb = NULL;
+	struct retro_log_callback logging;
+	
+	environ_cb = cb;
+	
+	if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &logging))
+		log_cb = logging.log;
+	else
+		log_cb = NULL;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_get_system_info(struct retro_system_info *info)
 {
-   memset(info, 0, sizeof(*info));
-   info->need_fullpath    = false;
-   info->valid_extensions = "min";
-   info->library_version  = "v0.60";
-   info->library_name     = "PokeMini";
-   info->block_extract    = false;
+	memset(info, 0, sizeof(*info));
+	info->need_fullpath    = false;
+	info->valid_extensions = "min";
+	info->library_version  = "v0.60";
+	info->library_name     = "PokeMini";
+	info->block_extract    = false;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-   info->geometry.base_width   = 320;
-   info->geometry.base_height  = 240;
-   info->geometry.max_width    = 320;
-   info->geometry.max_height   = 240;
-   info->geometry.aspect_ratio = 4.0 / 3.0;
-   info->timing.fps            = 72.0;
-   info->timing.sample_rate    = 44100.0;
+	info->geometry.base_width   = PM_VIDEO_WIDTH;
+	info->geometry.base_height  = PM_VIDEO_HEIGHT;
+	info->geometry.max_width    = PM_VIDEO_WIDTH;
+	info->geometry.max_height   = PM_VIDEO_HEIGHT;
+	info->geometry.aspect_ratio = (float)PM_VIDEO_WIDTH / (float)PM_VIDEO_HEIGHT;
+	info->timing.fps            = 72.0;
+	info->timing.sample_rate    = 44100.0;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_init (void)
 {
-   enum retro_pixel_format rgb565 = RETRO_PIXEL_FORMAT_RGB565;
-   if(environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &rgb565) && log_cb)
-         log_cb(RETRO_LOG_INFO, "Frontend supports RGB565 - will use that instead of XRGB1555.\n");
-
+	enum retro_pixel_format rgb565 = RETRO_PIXEL_FORMAT_RGB565;
+	if(environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &rgb565) && log_cb)
+		log_cb(RETRO_LOG_INFO, "Frontend supports RGB565 - will use that instead of XRGB1555.\n");
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_deinit(void)
 {
-   PokeMini_VideoPalette_Free();
-   PokeMini_Destroy();
+	PokeMini_VideoPalette_Free();
+	PokeMini_Destroy();
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_reset (void)
 {
-   PokeMini_Reset(1 /*hardreset*/);
+	// Soft reset
+	PokeMini_Reset(0);
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_run (void)
 {
-   int i;
-   int offset = 0;
-   static int16_t audiobuffer[612];
-   static int16_t audiostretched[612 * 2];
-   uint16_t audiosamples = 612;// MinxAudio_SamplesInBuffer();
-
-   poll_cb();
-   handlekeyevents();
-
-   PokeMini_EmulateFrame();
-
-   MinxAudio_GetSamplesS16(audiobuffer, audiosamples);
-   for(i = 0;i < 612;i++)
-   {
-      audiostretched[offset]     = audiobuffer[i];
-      audiostretched[offset + 1] = audiobuffer[i];
-      offset += 2;
-   }
-   audio_batch_cb(audiostretched, audiosamples);
-
-   if (PokeMini_Rumbling)
-      PokeMini_VideoBlit((uint16_t *)screenbuff + ScOffP + PokeMini_GenRumbleOffset(PixPitch), PixPitch);
-   else
-      PokeMini_VideoBlit((uint16_t *)screenbuff + ScOffP, PixPitch);
-
-   video_cb(screenbuff, 320, 240, 320*2/*Pitch*/);
+	int i;
+	int offset = 0;
+	static int16_t audiobuffer[612];
+	static int16_t audiostretched[612 * 2];
+	uint16_t audiosamples = 612;// MinxAudio_SamplesInBuffer();
+	
+	poll_cb();
+	handlekeyevents();
+	
+	PokeMini_EmulateFrame();
+	
+	MinxAudio_GetSamplesS16(audiobuffer, audiosamples);
+	for(i = 0;i < 612;i++)
+	{
+		audiostretched[offset]     = audiobuffer[i];
+		audiostretched[offset + 1] = audiobuffer[i];
+		offset += 2;
+	}
+	audio_batch_cb(audiostretched, audiosamples);
+	
+	if (PokeMini_Rumbling)
+		PokeMini_VideoBlit((uint16_t *)screenbuff + PokeMini_GenRumbleOffset(PixPitch), PixPitch);
+	else
+		PokeMini_VideoBlit((uint16_t *)screenbuff, PixPitch);
+	
+	video_cb(screenbuff, PM_VIDEO_WIDTH, PM_VIDEO_HEIGHT, PM_VIDEO_WIDTH * 2/*Pitch*/);
 }
+
+///////////////////////////////////////////////////////////
 
 size_t retro_serialize_size (void)
 {
-   return 0;
+	return 0;
 }
+
+///////////////////////////////////////////////////////////
 
 bool retro_serialize(void *data, size_t size)
 {
-   return false;
+	return false;
 }
+
+///////////////////////////////////////////////////////////
 
 bool retro_unserialize(const void * data, size_t size)
 {
-   return false;
+	return false;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_cheat_reset(void)
 {
-   //no cheats on this core
+	// no cheats on this core
 } 
+
+///////////////////////////////////////////////////////////
 
 void retro_cheat_set(unsigned index, bool enabled, const char *code)
 {
-   //no cheats on this core
+	// no cheats on this core
 } 
+
+///////////////////////////////////////////////////////////
 
 bool retro_load_game(const struct retro_game_info *game)
 {
-   int passed;
-   int userdefinedindex = 0;//make user defined later
-
-   if (!game)
-      return false;
-   
-   CommandLineInit();
-   CommandLine.joyenabled = 1;
-   
-   //add LCDMODE_COLORS option
-   // Set video spec and check if is supported
-   if (!PokeMini_SetVideo((TPokeMini_VideoSpec *)&PokeMini_Video3x3, 16, 0/*lcdfilter*//*0=none*/, LCDMODE_ANALOG/*lcdmode*/)) {
-      printf("Couldn't set video spec\n");
-      abort();
-   }
-   
-   passed = PokeMini_Create(0/*flags*/, PMSOUNDBUFF);//returns 1 on completion,0 on error
-   if(!passed)abort();
-   
-   PokeMini_VideoPalette_Init(PokeMini_RGB16, 1/*enablehighcolor*/);
-   PokeMini_VideoPalette_Index(userdefinedindex, NULL /*CustomMonoPal*/, 0/*int contrastboost*/, 0/*int brightoffset*/);
-   PokeMini_ApplyChanges();
-   
-   PokeMini_UseDefaultCallbacks();
-   
-   MinxAudio_ChangeEngine(MINX_AUDIO_DIRECTPWM);//enable sound
-   
-   passed = PokeMini_LoadMINFileXPLATFORM(game->size,(uint8_t*)game->data);//returns 1 on completion,0 on error
-   if(!passed)abort();
-   
-   PokeMini_Reset(1 /*hardreset*/);
-   return true;
+	int passed;
+	int userdefinedindex = 0; //make user defined later
+	
+	if (!game)
+		return false;
+	
+	CommandLineInit();
+	CommandLine.joyenabled = 1;
+	
+	//add LCDMODE_COLORS option
+	// Set video spec and check if is supported
+	if (!PokeMini_SetVideo((TPokeMini_VideoSpec *)&PokeMini_Video4x4, 16, 0/*lcdfilter*//*0=none*/, LCDMODE_ANALOG/*lcdmode*/))
+	{
+		printf("Couldn't set video spec\n");
+		abort();
+	}
+	
+	passed = PokeMini_Create(0/*flags*/, PMSOUNDBUFF);//returns 1 on completion,0 on error
+	if(!passed)abort();
+	
+	PokeMini_VideoPalette_Init(PokeMini_RGB16, 1/*enablehighcolor*/);
+	PokeMini_VideoPalette_Index(userdefinedindex, NULL /*CustomMonoPal*/, 0/*int contrastboost*/, 0/*int brightoffset*/);
+	PokeMini_ApplyChanges();
+	
+	PokeMini_UseDefaultCallbacks();
+	
+	MinxAudio_ChangeEngine(MINX_AUDIO_DIRECTPWM);//enable sound
+	
+	passed = PokeMini_LoadMINFileXPLATFORM(game->size,(uint8_t*)game->data);//returns 1 on completion,0 on error
+	if(!passed)abort();
+	
+	PokeMini_Reset(1 /*hardreset*/);
+	return true;
 }
 
-bool retro_load_game_special(
-  unsigned game_type,
-  const struct retro_game_info *info, size_t num_info
-)
+///////////////////////////////////////////////////////////
+
+bool retro_load_game_special(unsigned game_type, const struct retro_game_info *info, size_t num_info)
 {
-   return false;
+	return false;
 }
 
-void retro_unload_game (void){}
+///////////////////////////////////////////////////////////
 
+void retro_unload_game(void)
+{
+	
+}
 
-//useless callbacks
+// Useless (?) callbacks
+///////////////////////////////////////////////////////////
 
 unsigned retro_api_version(void)
 {
-   return RETRO_API_VERSION;
+	return RETRO_API_VERSION;
 }
+
+///////////////////////////////////////////////////////////
 
 void retro_set_controller_port_device(unsigned port, unsigned device)
 {
-   (void)port;
-   (void)device;
+	(void)port;
+	(void)device;
 }
+
+///////////////////////////////////////////////////////////
 
 unsigned retro_get_region (void)
 { 
-   return RETRO_REGION_NTSC;
+	return RETRO_REGION_NTSC;
 }
-


### PR DESCRIPTION
This pull request represents a quick attempt to make this core useable rather than just functional. It includes the following changes/additions:

- Enable save support
- Enable save state support (with caveats...)
- Allow configuration via core options interface
- Add input descriptors
- Add rumble support
- Allow loading of external bios
- Increase video scale from 3x to 4x (because it divides more cleanly into the most common display resolution of 1080p, and it greatly improves the look of the internal LCD filter); also remove unnecessary video padding and fix aspect ratio

The save state support is a little sticky, as I don't know how to portably create a memory stream in C that can be written to like a FILE (and I didn't want to rewrite the existing PokeMini save state code...). As a result, I read/write the serialised data to a temporary file, and make use of the default PokeMini save/load state functions. I guess someone else will need to look at improving how this works...

The actual code changes are very small and simple, and only affect libretro/libretro.c. I have verified the code functionality under Linux (unfortunately, I don't have the facility to test under other operating systems at present).

This is the first time I have used git, or done anything with the libretro API - I hope this pull request is acceptable. Please forgive me if I have done anything inappropriate!