### PR TITLE
Fix buffer overflow on long filename paths

### DIFF
--- a/source/PMCommon.h
+++ b/source/PMCommon.h
@@ -33,7 +33,7 @@
 // Minimum is 128
 // Recommended is 256
 #ifndef PMTMPV
-#define PMTMPV	256
+#define PMTMPV	512
 #endif
 
 #ifdef _WIN32

--- a/source/PokeMini.c
+++ b/source/PokeMini.c
@@ -544,7 +544,7 @@ int PokeMini_CheckSSFile(const char *statefile, char *romfile)
 {
 	FILE *fi;
 	int readbytes;
-	char PMiniStr[128];
+	char PMiniStr[PMTMPV];
 	uint32_t PMiniID;
 
 	// Open file
@@ -566,8 +566,8 @@ int PokeMini_CheckSSFile(const char *statefile, char *romfile)
 		if (PokeMini_OnLoadStateFile) PokeMini_OnLoadStateFile(statefile, -3);
 		return 0;
 	}
-	readbytes = fread(PMiniStr, 1, 128, fi);	// Read ROM related to state
-	if (readbytes != 128) {
+	readbytes = fread(PMiniStr, 1, 256, fi);	// Read ROM related to state
+	if (readbytes != 256) {
 		if (PokeMini_OnLoadStateFile) PokeMini_OnLoadStateFile(statefile, -4);
 		return 0;
 	}
@@ -583,7 +583,7 @@ int PokeMini_LoadSSFile(const char *statefile)
 {
 	FILE *fi;
 	int readbytes;
-	char PMiniStr[128];
+	char PMiniStr[PMTMPV];
 	uint32_t PMiniID, StatTime, BSize;
 
 	// Open file
@@ -606,8 +606,8 @@ int PokeMini_LoadSSFile(const char *statefile)
 		if (PokeMini_OnLoadStateFile) PokeMini_OnLoadStateFile(statefile, -3);
 		return 0;
 	}
-	readbytes = fread(PMiniStr, 1, 128, fi);	// Read ROM related to state (discarded)
-	if (readbytes != 128) {
+	readbytes = fread(PMiniStr, 1, 256, fi);	// Read ROM related to state (discarded)
+	if (readbytes != 256) {
 		if (PokeMini_OnLoadStateFile) PokeMini_OnLoadStateFile(statefile, -4);
 		return 0;
 	}
@@ -707,7 +707,7 @@ int PokeMini_LoadSSFile(const char *statefile)
 int PokeMini_SaveSSFile(const char *statefile, const char *romfile)
 {
 	FILE *fo;
-	char PMiniStr[128];
+	char PMiniStr[PMTMPV];
 	uint32_t PMiniID, StatTime, BSize;
 
 	// Open file
@@ -721,9 +721,9 @@ int PokeMini_SaveSSFile(const char *statefile, const char *romfile)
 	fwrite((void *)"PokeMiniStat", 1, 12, fo);	// Write File ID
 	PMiniID = PokeMini_ID;
 	fwrite(&PMiniID, 1, 4, fo);	// Write State ID
-	memset(PMiniStr, 0, 128);
+	memset(PMiniStr, 0, PMTMPV);
 	strcpy(PMiniStr, romfile);
-	fwrite(PMiniStr, 1, 128, fo);	// Write ROM related to state
+	fwrite(PMiniStr, 1, PMTMPV, fo);	// Write ROM related to state
 	StatTime = Endian32((uint32_t)time(NULL));
 	fwrite(&StatTime, 1, 4, fo);	// Write Time
 

--- a/source/UI.h
+++ b/source/UI.h
@@ -27,7 +27,7 @@
 
 // File list cache
 typedef struct {
-	char name[128]; // Filename					| Message
+	char name[PMTMPV]; // Filename					| Message
 	char stats;	// 0 = Invalid, 1 = Directory, 2 = File		| Unused
 	char color;	// 0 = Normal, 1 = Color available, 2 = Package	| 0 = Yellow, 1 = Aqua
 } TUIMenu_FileListCache;


### PR DESCRIPTION
iOS in particular uses long paths due to the nature of using UUID's as temporary sandbox paths.

I was running into issues with save states mostly on iOS simulator during testing since the simulator paths get pretty long.

Possibly another solution would be to take these changes minus the change of `#define PMTMPV	512` and just rely on iOS builds setting `PMTMPV` as a compiler flag. Still need the changes to use `PMTMPV` as the buffer size from the previous hard coded values.