### PR TITLE
Fix save states on big endian platforms

### DIFF
--- a/source/PokeMini.c
+++ b/source/PokeMini.c
@@ -727,14 +727,12 @@ int PokeMini_LoadSSStream(uint8_t *buffer, uint64_t size)
 		return 0;
 	}
 	readbytes = memstream_read(stream, &PMiniID, 4);	// Read State ID
-	PMiniID = Endian32(PMiniID);
 	if ((readbytes != 4) || (PMiniID != PokeMini_ID)) {
 		memstream_close(stream);
 		memstream_set_buffer(NULL, 0);
 		return 0;
 	}
 	readbytes = memstream_read(stream, &StatTime, 4);	// Read Time
-	StatTime = Endian32(StatTime);
 	if (readbytes != 4) {
 		memstream_close(stream);
 		memstream_set_buffer(NULL, 0);
@@ -751,7 +749,6 @@ int PokeMini_LoadSSStream(uint8_t *buffer, uint64_t size)
 			return 0;
 		}
 		readbytes = memstream_read(stream, &BSize, 4);
-		BSize = Endian32(BSize);
 		if (readbytes != 4) {
 			memstream_close(stream);
 			memstream_set_buffer(NULL, 0);
@@ -927,18 +924,18 @@ int PokeMini_SaveSSStream(uint8_t *buffer, uint64_t size)
 	memstream_write(stream, (void *)"PokeMiniStat", 12);	// Write File ID
 	PMiniID = PokeMini_ID;
 	memstream_write(stream, &PMiniID, 4);	// Write State ID
-	StatTime = Endian32((uint32_t)time(NULL));
+	StatTime = (uint32_t)time(NULL);
 	memstream_write(stream, &StatTime, 4);	// Write Time
 
 	// Read State Structure
 	// - RAM
 	memstream_write(stream, (void *)"RAM-", 4);
-	BSize = Endian32(0x1000);
+	BSize = 0x1000;
 	memstream_write(stream, &BSize, 4);
 	memstream_write(stream, PM_RAM, 0x1000);
 	// - Registers I/O
 	memstream_write(stream, (void *)"REG-", 4);
-	BSize = Endian32(256);
+	BSize = 256;
 	memstream_write(stream, &BSize, 4);
 	memstream_write(stream, PM_IO, 256);
 	// - CPU Interface
@@ -967,7 +964,7 @@ int PokeMini_SaveSSStream(uint8_t *buffer, uint64_t size)
 	MinxAudio_SaveStateStream(stream);
 	// - EOF
 	memstream_write(stream, (void *)"END-", 4);
-	BSize = Endian32(0);
+	BSize = 0;
 	memstream_write(stream, &BSize, 4);
 	memstream_close(stream);
 	memstream_set_buffer(NULL, 0);

--- a/source/PokeMini.h
+++ b/source/PokeMini.h
@@ -168,12 +168,12 @@ static inline void MinxPRC_OnWrite(int cpu, uint32_t addr, uint8_t data)
 // -- Stream versions START
 #define POKELOADSS_STREAM_32(var) {\
 	rsize += (uint32_t)memstream_read(stream, (void *)&tmp32, 4);\
-	var = Endian32(tmp32);\
+	var = tmp32;\
 }
 
 #define POKELOADSS_STREAM_16(var) {\
 	rsize += (uint32_t)memstream_read(stream, (void *)&tmp16, 2);\
-	var = Endian16(tmp16);\
+	var = tmp16;\
 }
 
 #define POKELOADSS_STREAM_8(var) {\
@@ -230,18 +230,18 @@ static inline void MinxPRC_OnWrite(int cpu, uint32_t addr, uint8_t data)
 // -- Stream versions START
 #define POKESAVESS_STREAM_START(size)\
 	uint32_t wsize = 0;\
-	uint32_t tmp32 = Endian32(size);\
+	uint32_t tmp32 = size;\
 	uint16_t tmp16;\
 	if (memstream_write(stream, (void *)&tmp32, 4) != 4) return 0;\
 	{ tmp32 = 0; tmp16 = 0; }
 
 #define POKESAVESS_STREAM_32(var) {\
-	tmp32 = Endian32((uint32_t)var);\
+	tmp32 = (uint32_t)var;\
 	wsize += (uint32_t)memstream_write(stream, (void *)&tmp32, 4);\
 }
 
 #define POKESAVESS_STREAM_16(var) {\
-	tmp16 = Endian16((uint16_t)var);\
+	tmp16 = (uint16_t)var;\
 	wsize += (uint32_t)memstream_write(stream, (void *)&tmp16, 2);\
 }
 


### PR DESCRIPTION
Save states are currently broken on big endian platforms (such as the Wii). This is because I copy/pasted from the old save state file code when implementing PR #18. My error was thus: whereas endianness correction is required when reading from/writing to file, the 'new' memory stream method is all in RAM - so byte-swapping for endianness just corrupts the data!

This PR removes save state endianness 'correction' - so the code now works correctly on all platforms.

