### PR TITLE
Add core option sublabels

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -13,6 +13,7 @@
 #include <fcntl.h>
 
 #include <libretro.h>
+#include <libretro_core_options.h>
 #include <retro_miscellaneous.h>
 /*
  bare functions to use
@@ -676,79 +677,6 @@ void retro_set_environment(retro_environment_t cb)
 {
 	struct retro_log_callback logging;
 	
-	struct retro_core_option_definition option_defs[] = {
-#ifdef _3DS
-		{
-			"pokemini_video_scale",
-			"Video Scale (Restart)",
-			"1x|2x|3x",
-			"Set internal video scale factor. Increasing the scale factor improves the appearance of the internal 'dotmatrix' LCD filter."
-		},
-#else
-		{
-			"pokemini_video_scale",
-			"Video Scale (Restart)",
-			"4x|5x|6x|1x|2x|3x",
-			"Set internal video scale factor. Increasing the scale factor improves the appearance of the internal 'dotmatrix' LCD filter."
-		},
-#endif
-		{
-			"pokemini_lcdfilter",
-			"LCD Filter",
-			"dotmatrix|scanline|none",
-			"Select internal screen filter. 'dotmatrix' produces an LCD effect that mimics real hardware. LCD filters are disabled when 'Video Scale' is set to '1x'."
-		},
-		{
-			"pokemini_lcdmode",
-			"LCD Mode",
-			"analog|3shades|2shades",
-			"Specify the greyscale 'color' reproduction characteristics of the emulated liquid crystal display. 'analog' mimics real hardware. '2shades' removes ghosting, but causes flickering in most games."
-		},
-		{
-			"pokemini_lcdcontrast",
-			"LCD Contrast",
-			"64|0|16|32|48|80|96",
-			"Set contrast level of emulated liquid crystal display."
-		},
-		{
-			"pokemini_lcdbright",
-			"LCD Brightness",
-			"0|-80|-60|-40|-20|20|40|60|80",
-			"Set brightness offset of emulated liquid crystal display."
-		},
-		{
-			"pokemini_palette",
-			"Palette",
-			"Default|Old|Monochrome|Green|Green Vector|Red|Red Vector|Blue LCD|LEDBacklight|Girl Power|Blue|Blue Vector|Sepia|Monochrome Vector",
-			"Specify palette used to 'colorize' the emulated liquid crystal display. 'Default' mimics real hardware. Palettes with a 'Vector' suffix correspond to inverted colors."
-		},
-		{
-			"pokemini_piezofilter",
-			"Piezo Filter",
-			"enabled|disabled",
-			"Use an audio filter to simulate the characteristics of the Pokemon Mini's piezoelectric speaker."
-		},
-		{
-			"pokemini_rumblelvl",
-			"Rumble Level (Screen + Controller)",
-			"3|2|1|0",
-			"Specify the magnitude of the force feedback effect, both virtual and physical."
-		},
-		{
-			"pokemini_controller_rumble",
-			"Controller Rumble",
-			"enabled|disabled",
-			"Enable physical force feedback effect via controller rumble."
-		},
-		{
-			"pokemini_screen_shake",
-			"Screen Shake",
-			"enabled|disabled",
-			"Enable virtual force feedback effect by 'shaking' the screen."
-		},
-		{ NULL, NULL, NULL, NULL },
-	};
-	
 	environ_cb = cb;
 	
 	if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &logging))
@@ -756,50 +684,7 @@ void retro_set_environment(retro_environment_t cb)
 	else
 		log_cb = NULL;
 	
-	if (environ_cb(RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS, NULL))
-		environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_defs);
-	else
-	{
-		size_t i;
-		size_t size = sizeof(option_defs) / sizeof(option_defs[0]);
-		struct retro_variable variables[sizeof(option_defs) / sizeof(option_defs[0])] = {{0}};
-		char *values_buff[sizeof(option_defs) / sizeof(option_defs[0])] = {0};
-		
-		/* Copy parameters from retro_core_option_definition array */
-		for (i = 0; i < size; i++)
-		{
-			const char *key    = option_defs[i].key;
-			const char *desc   = option_defs[i].desc;
-			const char *values = option_defs[i].values;
-			size_t buf_len     = 3;
-			
-			if (desc && values)
-			{
-				buf_len += strlen(desc) + strlen(values);
-				values_buff[i] = (char*)calloc(buf_len, sizeof(char));
-				
-				strcpy(values_buff[i], desc);
-				strcat(values_buff[i], "; ");
-				strcat(values_buff[i], values);
-			}
-			
-			variables[i].key   = key;
-			variables[i].value = values_buff[i];
-		}
-		
-		/* Set variables */
-		environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
-		
-		/* Clean up */
-		for (i = 0; i < size; i++)
-		{
-			if (values_buff[i])
-			{
-				free(values_buff[i]);
-				values_buff[i] = NULL;
-			}
-		}
-	}
+	libretro_set_core_options(environ_cb);
 }
 
 ///////////////////////////////////////////////////////////

--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -128,7 +128,8 @@ extern "C" {
 
 /* LIGHTGUN device is similar to Guncon-2 for PlayStation 2.
  * It reports X/Y coordinates in screen space (similar to the pointer)
- * in the range [-0x8000, 0x7fff] in both axes, with zero being center.
+ * in the range [-0x8000, 0x7fff] in both axes, with zero being center and
+ * -0x8000 being out of bounds.
  * As well as reporting on/off screen state. It features a trigger,
  * start/select buttons, auxiliary action buttons and a
  * directional pad. A forced off-screen shot can be requested for
@@ -139,7 +140,8 @@ extern "C" {
 /* The ANALOG device is an extension to JOYPAD (RetroPad).
  * Similar to DualShock2 it adds two analog sticks and all buttons can
  * be analog. This is treated as a separate device type as it returns
- * axis values in the full analog range of [-0x8000, 0x7fff].
+ * axis values in the full analog range of [-0x7fff, 0x7fff],
+ * although some devices may return -0x8000.
  * Positive X axis is right. Positive Y axis is down.
  * Buttons are returned in the range [0, 0x7fff].
  * Only use ANALOG type when polling for analog values.
@@ -200,6 +202,8 @@ extern "C" {
 #define RETRO_DEVICE_ID_JOYPAD_L3      14
 #define RETRO_DEVICE_ID_JOYPAD_R3      15
 
+#define RETRO_DEVICE_ID_JOYPAD_MASK    256
+
 /* Index / Id values for ANALOG device. */
 #define RETRO_DEVICE_INDEX_ANALOG_LEFT       0
 #define RETRO_DEVICE_INDEX_ANALOG_RIGHT      1
@@ -246,6 +250,7 @@ extern "C" {
 #define RETRO_DEVICE_ID_POINTER_X         0
 #define RETRO_DEVICE_ID_POINTER_Y         1
 #define RETRO_DEVICE_ID_POINTER_PRESSED   2
+#define RETRO_DEVICE_ID_POINTER_COUNT     3
 
 /* Returned from retro_get_region(). */
 #define RETRO_REGION_NTSC  0
@@ -272,6 +277,7 @@ enum retro_language
    RETRO_LANGUAGE_VIETNAMESE          = 15,
    RETRO_LANGUAGE_ARABIC              = 16,
    RETRO_LANGUAGE_GREEK               = 17,
+   RETRO_LANGUAGE_TURKISH             = 18,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -483,11 +489,13 @@ enum retro_mod
 /* Environment commands. */
 #define RETRO_ENVIRONMENT_SET_ROTATION  1  /* const unsigned * --
                                             * Sets screen rotation of graphics.
-                                            * Is only implemented if rotation can be accelerated by hardware.
                                             * Valid values are 0, 1, 2, 3, which rotates screen by 0, 90, 180,
                                             * 270 degrees counter-clockwise respectively.
                                             */
 #define RETRO_ENVIRONMENT_GET_OVERSCAN  2  /* bool * --
+                                            * NOTE: As of 2019 this callback is considered deprecated in favor of
+                                            * using core options to manage overscan in a more nuanced, core-specific way.
+                                            *
                                             * Boolean value whether or not the implementation should use overscan,
                                             * or crop away overscan.
                                             */
@@ -606,7 +614,7 @@ enum retro_mod
                                             * Afterward it may be called again for the core to communicate
                                             * updated options to the frontend, but the number of core
                                             * options must not change from the number in the initial call.
-					    *
+                                            *
                                             * 'data' points to an array of retro_variable structs
                                             * terminated by a { NULL, NULL } element.
                                             * retro_variable::key should be namespaced to not collide
@@ -873,12 +881,12 @@ enum retro_mod
                                             * types already defined in the libretro API.
                                             *
                                             * The core must pass an array of const struct retro_controller_info which
-                                            * is terminated with a blanked out struct. Each element of the 
+                                            * is terminated with a blanked out struct. Each element of the
                                             * retro_controller_info struct corresponds to the ascending port index
                                             * that is passed to retro_set_controller_port_device() when that function
                                             * is called to indicate to the core that the frontend has changed the
                                             * active device subclass. SEE ALSO: retro_set_controller_port_device()
-                                            * 
+                                            *
                                             * The ascending input port indexes provided by the core in the struct
                                             * are generally presented by frontends as ascending User # or Player #,
                                             * such as Player 1, Player 2, Player 3, etc. Which device subclasses are
@@ -890,7 +898,7 @@ enum retro_mod
                                             * User or Player, beginning with the generic Libretro device that the
                                             * subclasses are derived from. The second inner element of each entry is the
                                             * total number of subclasses that are listed in the retro_controller_description.
-                                            * 
+                                            *
                                             * NOTE: Even if special device types are set in the libretro core,
                                             * libretro should only poll input based on the base input device types.
                                             */
@@ -1077,10 +1085,94 @@ enum retro_mod
                                             * fastforwarding mode.
                                             */
 
+#define RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE (50 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                            /* float * --
+                                            * Float value that lets us know what target refresh rate 
+                                            * is curently in use by the frontend.
+                                            *
+                                            * The core can use the returned value to set an ideal 
+                                            * refresh rate/framerate.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_INPUT_BITMASKS (51 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                            /* bool * --
+                                            * Boolean value that indicates whether or not the frontend supports
+                                            * input bitmasks being returned by retro_input_state_t. The advantage
+                                            * of this is that retro_input_state_t has to be only called once to 
+                                            * grab all button states instead of multiple times.
+                                            *
+                                            * If it returns true, you can pass RETRO_DEVICE_ID_JOYPAD_MASK as 'id'
+                                            * to retro_input_state_t (make sure 'device' is set to RETRO_DEVICE_JOYPAD).
+                                            * It will return a bitmask of all the digital buttons.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS 52
+                                           /* bool * --
+                                            * If true, the libretro implementation supports enhanced
+                                            * core options definitions.
+                                            *
+                                            * In legacy code, core options are set by passing an array of
+                                            * retro_variable structs to RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This may be still be done regardless of whether enhanced
+                                            * core options are supported.
+                                            *
+                                            * If RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS does
+                                            * return true, however, core options may instead be set by
+                                            * passing an array of retro_core_option_definition structs to
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS. This allows the core
+                                            * to additionally set option sublabel information.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS 53
+                                           /* const struct retro_core_option_definition * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
+                                            * returns true, and instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            *
+                                            * 'data' points to an array of retro_core_option_definition structs
+                                            * terminated by a { NULL, NULL, NULL, NULL } element.
+                                            * retro_core_option_definition::key should be namespaced to not collide
+                                            * with other implementations' keys. E.g. A core called
+                                            * 'foo' should use keys named as 'foo_option'.
+                                            * retro_core_option_definition::desc should contain a human readable
+                                            * description of the key.
+                                            * retro_variable::values should contain a '|' delimited list
+                                            * of expected values.
+                                            * retro_core_option_definition::info should contain any additional human
+                                            * readable information text that a typical user may need to
+                                            * understand the functionality of the option.
+                                            *
+                                            * The number of possible options should be very limited,
+                                            * i.e. it should be feasible to cycle through options
+                                            * without a keyboard.
+                                            *
+                                            * First entry should be treated as a default.
+                                            *
+                                            * Example entry:
+                                            * {
+                                            *     "foo_option",
+                                            *     "Speed hack coprocessor X",
+                                            *     "false|true",
+                                            *     "Provides increased performance at the expense of reduced accuracy"
+                                            * }
+                                            *
+                                            * Only strings are operated on. The possible values will
+                                            * generally be displayed and stored as-is by the frontend.
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
- * File paths passed as parameters when using this api shall be well formed unix-style,
+ * File paths passed as parameters when using this API shall be well formed UNIX-style,
  * using "/" (unquoted forward slash) as directory separator regardless of the platform's native separator.
  * Paths shall also include at least one forward slash ("game.bin" is an invalid path, use "./game.bin" instead).
  * Other than the directory separator, cores shall not make assumptions about path format:
@@ -1097,6 +1189,10 @@ enum retro_mod
 /* Opaque file handle
  * Introduced in VFS API v1 */
 struct retro_vfs_file_handle;
+
+/* Opaque directory handle
+ * Introduced in VFS API v3 */
+struct retro_vfs_dir_handle;
 
 /* File open flags
  * Introduced in VFS API v1 */
@@ -1117,6 +1213,12 @@ struct retro_vfs_file_handle;
 #define RETRO_VFS_SEEK_POSITION_CURRENT  1
 #define RETRO_VFS_SEEK_POSITION_END      2
 
+/* stat() result flags
+ * Introduced in VFS API v3 */
+#define RETRO_VFS_STAT_IS_VALID               (1 << 0)
+#define RETRO_VFS_STAT_IS_DIRECTORY           (1 << 1)
+#define RETRO_VFS_STAT_IS_CHARACTER_SPECIAL   (1 << 2)
+
 /* Get path from opaque handle. Returns the exact same path passed to file_open when getting the handle
  * Introduced in VFS API v1 */
 typedef const char *(RETRO_CALLCONV *retro_vfs_get_path_t)(struct retro_vfs_file_handle *stream);
@@ -1126,7 +1228,7 @@ typedef const char *(RETRO_CALLCONV *retro_vfs_get_path_t)(struct retro_vfs_file
  * Introduced in VFS API v1 */
 typedef struct retro_vfs_file_handle *(RETRO_CALLCONV *retro_vfs_open_t)(const char *path, unsigned mode, unsigned hints);
 
-/* Close the file and release its resources. Must be called if open_file returns non-NULL. Returns 0 on succes, -1 on failure.
+/* Close the file and release its resources. Must be called if open_file returns non-NULL. Returns 0 on success, -1 on failure.
  * Whether the call succeeds ot not, the handle passed as parameter becomes invalid and should no longer be used.
  * Introduced in VFS API v1 */
 typedef int (RETRO_CALLCONV *retro_vfs_close_t)(struct retro_vfs_file_handle *stream);
@@ -1139,7 +1241,7 @@ typedef int64_t (RETRO_CALLCONV *retro_vfs_size_t)(struct retro_vfs_file_handle 
  * Introduced in VFS API v2 */
 typedef int64_t (RETRO_CALLCONV *retro_vfs_truncate_t)(struct retro_vfs_file_handle *stream, int64_t length);
 
-/* Get the current read / write position for the file. Returns - 1 for error.
+/* Get the current read / write position for the file. Returns -1 for error.
  * Introduced in VFS API v1 */
 typedef int64_t (RETRO_CALLCONV *retro_vfs_tell_t)(struct retro_vfs_file_handle *stream);
 
@@ -1167,6 +1269,39 @@ typedef int (RETRO_CALLCONV *retro_vfs_remove_t)(const char *path);
  * Introduced in VFS API v1 */
 typedef int (RETRO_CALLCONV *retro_vfs_rename_t)(const char *old_path, const char *new_path);
 
+/* Stat the specified file. Retruns a bitmask of RETRO_VFS_STAT_* flags, none are set if path was not valid.
+ * Additionally stores file size in given variable, unless NULL is given.
+ * Introduced in VFS API v3 */
+typedef int (RETRO_CALLCONV *retro_vfs_stat_t)(const char *path, int32_t *size);
+
+/* Create the specified directory. Returns 0 on success, -1 on unknown failure, -2 if already exists.
+ * Introduced in VFS API v3 */
+typedef int (RETRO_CALLCONV *retro_vfs_mkdir_t)(const char *dir);
+
+/* Open the specified directory for listing. Returns the opaque dir handle, or NULL for error.
+ * Support for the include_hidden argument may vary depending on the platform.
+ * Introduced in VFS API v3 */
+typedef struct retro_vfs_dir_handle *(RETRO_CALLCONV *retro_vfs_opendir_t)(const char *dir, bool include_hidden);
+
+/* Read the directory entry at the current position, and move the read pointer to the next position.
+ * Returns true on success, false if already on the last entry.
+ * Introduced in VFS API v3 */
+typedef bool (RETRO_CALLCONV *retro_vfs_readdir_t)(struct retro_vfs_dir_handle *dirstream);
+
+/* Get the name of the last entry read. Returns a string on success, or NULL for error.
+ * The returned string pointer is valid until the next call to readdir or closedir.
+ * Introduced in VFS API v3 */
+typedef const char *(RETRO_CALLCONV *retro_vfs_dirent_get_name_t)(struct retro_vfs_dir_handle *dirstream);
+
+/* Check if the last entry read was a directory. Returns true if it was, false otherwise (or on error).
+ * Introduced in VFS API v3 */
+typedef bool (RETRO_CALLCONV *retro_vfs_dirent_is_dir_t)(struct retro_vfs_dir_handle *dirstream);
+
+/* Close the directory and release its resources. Must be called if opendir returns non-NULL. Returns 0 on success, -1 on failure.
+ * Whether the call succeeds ot not, the handle passed as parameter becomes invalid and should no longer be used.
+ * Introduced in VFS API v3 */
+typedef int (RETRO_CALLCONV *retro_vfs_closedir_t)(struct retro_vfs_dir_handle *dirstream);
+
 struct retro_vfs_interface
 {
    /* VFS API v1 */
@@ -1183,6 +1318,14 @@ struct retro_vfs_interface
 	retro_vfs_rename_t rename;
    /* VFS API v2 */
    retro_vfs_truncate_t truncate;
+   /* VFS API v3 */
+   retro_vfs_stat_t stat;
+   retro_vfs_mkdir_t mkdir;
+   retro_vfs_opendir_t opendir;
+   retro_vfs_readdir_t readdir;
+   retro_vfs_dirent_get_name_t dirent_get_name;
+   retro_vfs_dirent_is_dir_t dirent_is_dir;
+   retro_vfs_closedir_t closedir;
 };
 
 struct retro_vfs_interface_info
@@ -1205,6 +1348,7 @@ enum retro_hw_render_interface_type
 	RETRO_HW_RENDER_INTERFACE_D3D10  = 2,
 	RETRO_HW_RENDER_INTERFACE_D3D11  = 3,
 	RETRO_HW_RENDER_INTERFACE_D3D12  = 4,
+   RETRO_HW_RENDER_INTERFACE_GSKIT_PS2  = 5,
    RETRO_HW_RENDER_INTERFACE_DUMMY  = INT_MAX
 };
 
@@ -2268,6 +2412,21 @@ struct retro_variable
 
    /* Value to be obtained. If key does not exist, it is set to NULL. */
    const char *value;
+};
+
+struct retro_core_option_definition
+{
+   /* Variable to query in RETRO_ENVIRONMENT_GET_VARIABLE. */
+   const char *key;
+
+   /* Human-readable core option description (used as menu label) */
+   const char *desc;
+
+   /* '|' delimited list of expected values. */
+   const char *values;
+
+   /* Human-readable core option information (used as menu sublabel) */
+   const char *info;
 };
 
 struct retro_game_info

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1,0 +1,483 @@
+#ifndef LIBRETRO_CORE_OPTIONS_H__
+#define LIBRETRO_CORE_OPTIONS_H__
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <libretro.h>
+#include <retro_inline.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_ENGLISH */
+
+/* Default language:
+ * - All other languages must include the same keys and values
+ * - Will be used as a fallback in the event that frontend language
+ *   is not available
+ * - Will be used as a fallback for any missing entries in
+ *   frontend language definition */
+
+struct retro_core_option_definition option_defs_us[] = {
+   {
+      "pokemini_video_scale",
+      "Video Scale (Restart)",
+      "Set internal video scale factor. Increasing the scale factor improves the appearance of the internal 'Dot Matrix' LCD filter.",
+      {
+#ifdef _3DS
+         { "1x", NULL },
+         { "2x", NULL },
+         { "3x", NULL },
+#else
+         { "4x", NULL },
+         { "5x", NULL },
+         { "6x", NULL },
+         { "1x", NULL },
+         { "2x", NULL },
+         { "3x", NULL },
+#endif
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_lcdfilter",
+      "LCD Filter",
+      "Select internal screen filter. 'Dot Matrix' produces an LCD effect that mimics real hardware. LCD filters are disabled when 'Video Scale' is set to '1x'.",
+      {
+         { "dotmatrix", "Dot Matrix" },
+         { "scanline",  "Scanlines" },
+         { "none",      "None" },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_lcdmode",
+      "LCD Mode",
+      "Specify the greyscale 'color' reproduction characteristics of the emulated liquid crystal display. 'Analog' mimics real hardware. '2 Shades' removes ghosting, but causes flickering in most games.",
+      {
+         { "analog",  "Analog" },
+         { "3shades", "3 Shades" },
+         { "2shades", "2 Shades" },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_lcdcontrast",
+      "LCD Contrast",
+      "Set contrast level of emulated liquid crystal display.",
+      {
+         { "64", NULL },
+         { "0",  NULL },
+         { "16", NULL },
+         { "32", NULL },
+         { "48", NULL },
+         { "80", NULL },
+         { "96", NULL },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_lcdbright",
+      "LCD Brightness",
+      "Set brightness offset of emulated liquid crystal display.",
+      {
+         { "0",   NULL },
+         { "-80", NULL },
+         { "-60", NULL },
+         { "-40", NULL },
+         { "-20", NULL },
+         { "20",  NULL },
+         { "40",  NULL },
+         { "60",  NULL },
+         { "80",  NULL },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_palette",
+      "Palette",
+      "Specify palette used to 'colorize' the emulated liquid crystal display. 'Default' mimics real hardware.",
+      {
+         { "Default",           "Default" },
+         { "Old",               "Old" },
+         { "Monochrome",        "Black & White" },
+         { "Green",             "Green" },
+         { "Green Vector",      "Inverted Green" },
+         { "Red",               "Red" },
+         { "Red Vector",        "Inverted Red" },
+         { "Blue LCD",          "Blue LCD" },
+         { "LEDBacklight",      "LED Backlight" },
+         { "Girl Power",        "Girl Power" },
+         { "Blue",              "Blue" },
+         { "Blue Vector",       "Inverted Blue" },
+         { "Sepia",             "Sepia" },
+         { "Monochrome Vector", "Inverted Black & White" },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_piezofilter",
+      "Piezo Filter",
+      "Use an audio filter to simulate the characteristics of the Pokemon Mini's piezoelectric speaker.",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_rumblelvl",
+      "Rumble Level (Screen + Controller)",
+      "Specify the magnitude of the force feedback effect, both virtual and physical.",
+      {
+         { "3", NULL },
+         { "2", NULL },
+         { "1", NULL },
+         { "0", NULL },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_controller_rumble",
+      "Controller Rumble",
+      "Enable physical force feedback effect via controller rumble.",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_screen_shake",
+      "Screen Shake",
+      "Enable virtual force feedback effect by 'shaking' the screen.",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      }
+   },
+   { NULL, NULL, NULL, {{0}} },
+};
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+struct retro_core_option_definition option_defs_fr[] = {
+   {
+      "pokemini_video_scale",
+      "Échelle vidéo (redémarrer)",
+      "Définir le facteur d'échelle vidéo interne. L'augmentation du facteur d'échelle améliore l'apparence du filtre LCD interne «Matrice de Points».",
+      {
+         { NULL, NULL }, /* Scale factors do not require translation */
+      }
+   },
+   {
+      "pokemini_lcdfilter",
+      "Filtre LCD",
+      "Sélectionnez le filtre d'écran interne. «Matrice de Points» produit un effet LCD qui imite le matériel réel. Les filtres LCD sont désactivés lorsque «Échelle vidéo» est défini sur «1x».",
+      {
+         { "dotmatrix", "Matrice de Points" },
+         { "scanline",  "Lignes de Balayage" },
+         { "none",      "Aucun" },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_lcdmode",
+      "Mode LCD",
+      "Spécifiez les caractéristiques de reproduction 'couleur' ​​en niveaux de gris de l'affichage à cristaux liquides émulé. «Analogique» imite le matériel réel. «2 Nuances» supprime les images fantômes, mais provoque un scintillement dans la plupart des jeux.",
+      {
+         { "analog",  "Analogique" },
+         { "3shades", "3 Nuances" },
+         { "2shades", "2 Nuances" },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_lcdcontrast",
+      "Contraste LCD",
+      "Réglez le niveau de contraste de l’écran à cristaux liquides émulé.",
+      {
+         { NULL, NULL }, /* Numbers do not require translation */
+      }
+   },
+   {
+      "pokemini_lcdbright",
+      "Luminosité de l'écran LCD",
+      "Définissez le décalage de luminosité de l’affichage à cristaux liquides émulé.",
+      {
+         { NULL, NULL }, /* Numbers do not require translation */
+      }
+   },
+   {
+      "pokemini_palette",
+      "Palette",
+      "Spécifiez la palette utilisée pour 'coloriser' l'affichage à cristaux liquides émulé. «Défaut» imite le matériel réel.",
+      {
+         { "Default",           "Défaut" },
+         { "Old",               "Vieux" },
+         { "Monochrome",        "Noir et Blanc" },
+         { "Green",             "Vert" },
+         { "Green Vector",      "Vert Inversé" },
+         { "Red",               "Rouge" },
+         { "Red Vector",        "Rouge Inversé" },
+         { "Blue LCD",          "LCD Bleu" },
+         { "LEDBacklight",      "Rétro-éclairage LED" },
+         { "Girl Power",        "Pouvoir des Filles" },
+         { "Blue",              "Bleu" },
+         { "Blue Vector",       "Bleu Inversé" },
+         { "Sepia",             "Sépia" },
+         { "Monochrome Vector", "Noir et Blanc Inversé" },
+         { NULL, NULL },
+      }
+   },
+   {
+      "pokemini_piezofilter",
+      "Filtre Piézo",
+      "Utilisez un filtre audio pour simuler les caractéristiques du haut-parleur piézoélectrique du Pokemon Mini.",
+      {
+         { NULL, NULL }, /* enabled/disabled strings do not require translation */
+      }
+   },
+   {
+      "pokemini_rumblelvl",
+      "Niveau de Rumble (écran + contrôleur)",
+      "Spécifiez l'ampleur de l'effet de retour de force, à la fois virtuel et physique.",
+      {
+         { NULL, NULL }, /* Numbers do not require translation */
+      }
+   },
+   {
+      "pokemini_controller_rumble",
+      "Contrôleur Rumble",
+      "Activer l'effet de retour de force physique via le roulement du contrôleur.",
+      {
+         { NULL, NULL }, /* enabled/disabled strings do not require translation */
+      }
+   },
+   {
+      "pokemini_screen_shake",
+      "Secousse de l'écran",
+      "Activez l'effet de retour de force virtuel en 'secouant' l'écran.",
+      {
+         { NULL, NULL }, /* enabled/disabled strings do not require translation */
+      }
+   },
+   { NULL, NULL, NULL, {{0}} },
+};
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+/*
+ ********************************
+ * Language Mapping
+ ********************************
+*/
+
+struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
+   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,           /* RETRO_LANGUAGE_JAPANESE */
+   option_defs_fr, /* RETRO_LANGUAGE_FRENCH */
+   NULL,           /* RETRO_LANGUAGE_SPANISH */
+   NULL,           /* RETRO_LANGUAGE_GERMAN */
+   NULL,           /* RETRO_LANGUAGE_ITALIAN */
+   NULL,           /* RETRO_LANGUAGE_DUTCH */
+   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,           /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,           /* RETRO_LANGUAGE_KOREAN */
+   NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,           /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,           /* RETRO_LANGUAGE_POLISH */
+   NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,           /* RETRO_LANGUAGE_ARABIC */
+   NULL,           /* RETRO_LANGUAGE_GREEK */
+   NULL,           /* RETRO_LANGUAGE_TURKISH */
+};
+
+/*
+ ********************************
+ * Functions
+ ********************************
+*/
+
+/* Handles configuration/setting of core options.
+ * Should only be called inside retro_set_environment().
+ * > We place the function body in the header to avoid the
+ *   necessity of adding more .c files (i.e. want this to
+ *   be as painless as possible for core devs)
+ */
+
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+{
+   unsigned version = 0;
+
+   if (!environ_cb)
+      return;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version == 1))
+   {
+      struct retro_core_options_intl core_options_intl;
+      unsigned language = 0;
+
+      core_options_intl.us    = option_defs_us;
+      core_options_intl.local = NULL;
+
+      if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+          (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
+         core_options_intl.local = option_defs_intl[language];
+
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+   }
+   else
+   {
+      size_t i;
+      size_t num_options               = 0;
+      struct retro_variable *variables = NULL;
+      char **values_buf                = NULL;
+
+      /* Determine number of options */
+      while (true)
+      {
+         if (option_defs_us[num_options].key)
+            num_options++;
+         else
+            break;
+      }
+
+      /* Allocate arrays */
+      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
+      values_buf = (char **)calloc(num_options, sizeof(char *));
+
+      if (!variables || !values_buf)
+         goto error;
+
+      /* Copy parameters from option_defs_us array */
+      for (i = 0; i < num_options; i++)
+      {
+         const char *key                        = option_defs_us[i].key;
+         const char *desc                       = option_defs_us[i].desc;
+         struct retro_core_option_value *values = option_defs_us[i].values;
+         size_t buf_len                         = 3;
+
+         values_buf[i] = NULL;
+
+         if (desc)
+         {
+            size_t num_values = 0;
+
+            /* Determine number of values */
+            while (true)
+            {
+               if (values[num_values].value)
+               {
+                  buf_len += strlen(values[num_values].value);
+                  num_values++;
+               }
+               else
+                  break;
+            }
+
+            /* Build values string */
+            if (num_values > 1)
+            {
+               size_t j;
+
+               buf_len += num_values - 1;
+               buf_len += strlen(desc);
+
+               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+               if (!values_buf[i])
+                  goto error;
+
+               strcpy(values_buf[i], desc);
+               strcat(values_buf[i], "; ");
+
+               for (j = 0; j < num_values; j++)
+               {
+                  strcat(values_buf[i], values[j].value);
+                  if (j != num_values - 1)
+                     strcat(values_buf[i], "|");
+               }
+            }
+         }
+
+         variables[i].key   = key;
+         variables[i].value = values_buf[i];
+      }
+      
+      /* Set variables */
+      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+
+error:
+
+      /* Clean up */
+      if (values_buf)
+      {
+         for (i = 0; i < num_options; i++)
+         {
+            if (values_buf[i])
+            {
+               free(values_buf[i]);
+               values_buf[i] = NULL;
+            }
+         }
+
+         free(values_buf);
+         values_buf = NULL;
+      }
+
+      if (variables)
+      {
+         free(variables);
+         variables = NULL;
+      }
+   }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
*Do not merge yet*

This PR adds core option sublabels.

It is intended as a demonstration of functionality that will be added in a forthcoming RetroArch PR (and should not be merged until the details of that PR are finalised)

I'll post a comment when it's ready to go.