### PR TITLE
Add abililty to hide LCD filter core option when video scale is 1x

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -517,6 +517,18 @@ static void InitialiseVideo(void)
 		}
 #endif
 	}
+
+	// If video scale is 1x, LCD filter is disabled
+	// > hide pokemini_lcdfilter core option
+	if (video_scale == 1)
+	{
+		struct retro_core_option_display option_display;
+
+		option_display.key     = "pokemini_lcdfilter";
+		option_display.visible = false;
+
+		environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+	}
 	
 	// Determine video dimensions
 	video_width = PM_SCEEN_WIDTH * video_scale;

--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -1218,6 +1218,26 @@ enum retro_mod
                                             * instead.
                                             */
 
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY 55
+                                           /* struct retro_core_option_display * --
+                                            *
+                                            * Allows an implementation to signal the environment to show
+                                            * or hide a variable when displaying core options. This is
+                                            * considered a *suggestion*. The frontend is free to ignore
+                                            * this callback, and its implementation not considered mandatory.
+                                            *
+                                            * 'data' points to a retro_core_option_display struct
+                                            *
+                                            * retro_core_option_display::key is a variable identifier
+                                            * which has already been set by SET_VARIABLES/SET_CORE_OPTIONS.
+                                            *
+                                            * retro_core_option_display::visible is a boolean, specifying
+                                            * whether variable should be displayed
+                                            *
+                                            * Note that all core option variables will be set visible by
+                                            * default when calling SET_VARIABLES/SET_CORE_OPTIONS.
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
@@ -2461,6 +2481,16 @@ struct retro_variable
 
    /* Value to be obtained. If key does not exist, it is set to NULL. */
    const char *value;
+};
+
+struct retro_core_option_display
+{
+   /* Variable to configure in RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY */
+   const char *key;
+
+   /* Specifies whether variable should be displayed
+    * when presenting core options to the user */
+   bool visible;
 };
 
 /* Maximum number of values permitted for a core option


### PR DESCRIPTION
This PR adds the facility to automatically hide the LCD filter core option when the feature is disabled by the current video scale setting.

It is intended as a demonstration of functionality that will be added in a forthcoming RetroArch PR.