### PR TITLE
Add core options v1 default value settings

### DIFF
--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -1142,7 +1142,7 @@ enum retro_mod
                                             * options must not change from the number in the initial call.
                                             *
                                             * 'data' points to an array of retro_core_option_definition structs
-                                            * terminated by a { NULL, NULL, NULL, {{0}} } element.
+                                            * terminated by a { NULL, NULL, NULL, {{0}}, NULL } element.
                                             * retro_core_option_definition::key should be namespaced to not collide
                                             * with other implementations' keys. e.g. A core called
                                             * 'foo' should use keys named as 'foo_option'.
@@ -1151,13 +1151,18 @@ enum retro_mod
                                             * retro_core_option_definition::info should contain any additional human
                                             * readable information text that a typical user may need to
                                             * understand the functionality of the option.
-                                            * retro_variable::values is an array of retro_core_option_value
+                                            * retro_core_option_definition::values is an array of retro_core_option_value
                                             * structs terminated by a { NULL, NULL } element.
-                                            * > retro_variable::values[index].value is an expected option
+                                            * > retro_core_option_definition::values[index].value is an expected option
                                             *   value.
-                                            * > retro_variable::values[index].label is a human readable
+                                            * > retro_core_option_definition::values[index].label is a human readable
                                             *   label used when displaying the value on screen. If NULL,
                                             *   the value itself is used.
+                                            * retro_core_option_definition::default_value is the default core option
+                                            * setting. It must match one of the expected option values in the
+                                            * retro_core_option_definition::values array. If it does not, or the
+                                            * default value is NULL, the first entry in the
+                                            * retro_core_option_definition::values array is treated as the default.
                                             *
                                             * The number of possible options should be very limited,
                                             * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
@@ -1176,7 +1181,8 @@ enum retro_mod
                                             *         { "true",     NULL },
                                             *         { "unstable", "Turbo (Unstable)" },
                                             *         { NULL, NULL },
-                                            *     }
+                                            *     },
+                                            *     "false"
                                             * }
                                             *
                                             * Only strings are operated on. The possible values will
@@ -1216,6 +1222,10 @@ enum retro_mod
                                             * retro_core_options_intl::us is used by the frontend). Any items
                                             * missing from this array will be read from retro_core_options_intl::us
                                             * instead.
+                                            *
+                                            * NOTE: Default core option values are always taken from the
+                                            * retro_core_options_intl::us array. Any default values in
+                                            * retro_core_options_intl::local array will be ignored.
                                             */
 
 #define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY 55
@@ -2521,6 +2531,11 @@ struct retro_core_option_definition
 
    /* Array of retro_core_option_value structs, terminated by NULL */
    struct retro_core_option_value values[RETRO_NUM_CORE_OPTION_VALUES_MAX];
+
+   /* Default core option value. Must match one of the values
+    * in the retro_core_option_value array, otherwise will be
+    * ignored */
+   const char *default_value;
 };
 
 struct retro_core_options_intl

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -45,7 +45,12 @@ struct retro_core_option_definition option_defs_us[] = {
          { "3x", NULL },
 #endif
          { NULL, NULL },
-      }
+      },
+#ifdef _3DS
+      "1x"
+#else
+      "4x"
+#endif
    },
    {
       "pokemini_lcdfilter",
@@ -56,7 +61,8 @@ struct retro_core_option_definition option_defs_us[] = {
          { "scanline",  "Scanlines" },
          { "none",      "None" },
          { NULL, NULL },
-      }
+      },
+      "dotmatrix"
    },
    {
       "pokemini_lcdmode",
@@ -67,7 +73,8 @@ struct retro_core_option_definition option_defs_us[] = {
          { "3shades", "3 Shades" },
          { "2shades", "2 Shades" },
          { NULL, NULL },
-      }
+      },
+      "analog"
    },
    {
       "pokemini_lcdcontrast",
@@ -82,7 +89,8 @@ struct retro_core_option_definition option_defs_us[] = {
          { "80", NULL },
          { "96", NULL },
          { NULL, NULL },
-      }
+      },
+      "64"
    },
    {
       "pokemini_lcdbright",
@@ -99,7 +107,8 @@ struct retro_core_option_definition option_defs_us[] = {
          { "60",  NULL },
          { "80",  NULL },
          { NULL, NULL },
-      }
+      },
+      "0"
    },
    {
       "pokemini_palette",
@@ -121,7 +130,8 @@ struct retro_core_option_definition option_defs_us[] = {
          { "Sepia",             "Sepia" },
          { "Monochrome Vector", "Inverted Black & White" },
          { NULL, NULL },
-      }
+      },
+      "Default"
    },
    {
       "pokemini_piezofilter",
@@ -131,7 +141,8 @@ struct retro_core_option_definition option_defs_us[] = {
          { "enabled",  NULL },
          { "disabled", NULL },
          { NULL, NULL },
-      }
+      },
+      "enabled"
    },
    {
       "pokemini_rumblelvl",
@@ -143,7 +154,8 @@ struct retro_core_option_definition option_defs_us[] = {
          { "1", NULL },
          { "0", NULL },
          { NULL, NULL },
-      }
+      },
+      "3"
    },
    {
       "pokemini_controller_rumble",
@@ -153,7 +165,8 @@ struct retro_core_option_definition option_defs_us[] = {
          { "enabled",  NULL },
          { "disabled", NULL },
          { NULL, NULL },
-      }
+      },
+      "enabled"
    },
    {
       "pokemini_screen_shake",
@@ -163,9 +176,10 @@ struct retro_core_option_definition option_defs_us[] = {
          { "enabled",  NULL },
          { "disabled", NULL },
          { NULL, NULL },
-      }
+      },
+      "enabled"
    },
-   { NULL, NULL, NULL, {{0}} },
+   { NULL, NULL, NULL, {{0}}, NULL },
 };
 
 /* RETRO_LANGUAGE_JAPANESE */
@@ -179,7 +193,8 @@ struct retro_core_option_definition option_defs_fr[] = {
       "Définir le facteur d'échelle vidéo interne. L'augmentation du facteur d'échelle améliore l'apparence du filtre LCD interne «Matrice de Points».",
       {
          { NULL, NULL }, /* Scale factors do not require translation */
-      }
+      },
+      NULL
    },
    {
       "pokemini_lcdfilter",
@@ -190,7 +205,8 @@ struct retro_core_option_definition option_defs_fr[] = {
          { "scanline",  "Lignes de Balayage" },
          { "none",      "Aucun" },
          { NULL, NULL },
-      }
+      },
+      NULL
    },
    {
       "pokemini_lcdmode",
@@ -201,7 +217,8 @@ struct retro_core_option_definition option_defs_fr[] = {
          { "3shades", "3 Nuances" },
          { "2shades", "2 Nuances" },
          { NULL, NULL },
-      }
+      },
+      NULL
    },
    {
       "pokemini_lcdcontrast",
@@ -209,7 +226,8 @@ struct retro_core_option_definition option_defs_fr[] = {
       "Réglez le niveau de contraste de l’écran à cristaux liquides émulé.",
       {
          { NULL, NULL }, /* Numbers do not require translation */
-      }
+      },
+      NULL
    },
    {
       "pokemini_lcdbright",
@@ -217,7 +235,8 @@ struct retro_core_option_definition option_defs_fr[] = {
       "Définissez le décalage de luminosité de l’affichage à cristaux liquides émulé.",
       {
          { NULL, NULL }, /* Numbers do not require translation */
-      }
+      },
+      NULL
    },
    {
       "pokemini_palette",
@@ -239,7 +258,8 @@ struct retro_core_option_definition option_defs_fr[] = {
          { "Sepia",             "Sépia" },
          { "Monochrome Vector", "Noir et Blanc Inversé" },
          { NULL, NULL },
-      }
+      },
+      NULL
    },
    {
       "pokemini_piezofilter",
@@ -247,7 +267,8 @@ struct retro_core_option_definition option_defs_fr[] = {
       "Utilisez un filtre audio pour simuler les caractéristiques du haut-parleur piézoélectrique du Pokemon Mini.",
       {
          { NULL, NULL }, /* enabled/disabled strings do not require translation */
-      }
+      },
+      NULL
    },
    {
       "pokemini_rumblelvl",
@@ -255,7 +276,8 @@ struct retro_core_option_definition option_defs_fr[] = {
       "Spécifiez l'ampleur de l'effet de retour de force, à la fois virtuel et physique.",
       {
          { NULL, NULL }, /* Numbers do not require translation */
-      }
+      },
+      NULL
    },
    {
       "pokemini_controller_rumble",
@@ -263,7 +285,8 @@ struct retro_core_option_definition option_defs_fr[] = {
       "Activer l'effet de retour de force physique via le roulement du contrôleur.",
       {
          { NULL, NULL }, /* enabled/disabled strings do not require translation */
-      }
+      },
+      NULL
    },
    {
       "pokemini_screen_shake",
@@ -271,7 +294,8 @@ struct retro_core_option_definition option_defs_fr[] = {
       "Activez l'effet de retour de force virtuel en 'secouant' l'écran.",
       {
          { NULL, NULL }, /* enabled/disabled strings do not require translation */
-      }
+      },
+      NULL
    },
    { NULL, NULL, NULL, {{0}} },
 };


### PR DESCRIPTION
This PR adds default core options settings using the new extension to the v1 core options interface.

It is intended as a demonstration of functionality that will be added in a forthcoming RetroArch PR.