### PR TITLE
Sanitise order of core option values

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -32,17 +32,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "Video Scale (Restart)",
       "Set internal video scale factor. Increasing the scale factor improves the appearance of the internal 'Dot Matrix' LCD filter.",
       {
-#ifdef _3DS
          { "1x", NULL },
          { "2x", NULL },
          { "3x", NULL },
-#else
+#ifndef _3DS
          { "4x", NULL },
          { "5x", NULL },
          { "6x", NULL },
-         { "1x", NULL },
-         { "2x", NULL },
-         { "3x", NULL },
 #endif
          { NULL, NULL },
       },
@@ -81,11 +77,11 @@ struct retro_core_option_definition option_defs_us[] = {
       "LCD Contrast",
       "Set contrast level of emulated liquid crystal display.",
       {
-         { "64", NULL },
          { "0",  NULL },
          { "16", NULL },
          { "32", NULL },
          { "48", NULL },
+         { "64", NULL },
          { "80", NULL },
          { "96", NULL },
          { NULL, NULL },
@@ -97,11 +93,11 @@ struct retro_core_option_definition option_defs_us[] = {
       "LCD Brightness",
       "Set brightness offset of emulated liquid crystal display.",
       {
-         { "0",   NULL },
          { "-80", NULL },
          { "-60", NULL },
          { "-40", NULL },
          { "-20", NULL },
+         { "0",   NULL },
          { "20",  NULL },
          { "40",  NULL },
          { "60",  NULL },
@@ -149,10 +145,10 @@ struct retro_core_option_definition option_defs_us[] = {
       "Rumble Level (Screen + Controller)",
       "Specify the magnitude of the force feedback effect, both virtual and physical.",
       {
-         { "3", NULL },
-         { "2", NULL },
-         { "1", NULL },
          { "0", NULL },
+         { "1", NULL },
+         { "2", NULL },
+         { "3", NULL },
          { NULL, NULL },
       },
       "3"
@@ -422,8 +418,10 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
       {
          const char *key                        = option_defs_us[i].key;
          const char *desc                       = option_defs_us[i].desc;
+         const char *default_value              = option_defs_us[i].default_value;
          struct retro_core_option_value *values = option_defs_us[i].values;
          size_t buf_len                         = 3;
+         size_t default_index                   = 0;
 
          values_buf[i] = NULL;
 
@@ -436,6 +434,11 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             {
                if (values[num_values].value)
                {
+                  /* Check if this is the default value */
+                  if (default_value)
+                     if (strcmp(values[num_values].value, default_value) == 0)
+                        default_index = num_values;
+
                   buf_len += strlen(values[num_values].value);
                   num_values++;
                }
@@ -458,11 +461,17 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
                strcpy(values_buf[i], desc);
                strcat(values_buf[i], "; ");
 
+               /* Default value goes first */
+               strcat(values_buf[i], values[default_index].value);
+
+               /* Add remaining values */
                for (j = 0; j < num_values; j++)
                {
-                  strcat(values_buf[i], values[j].value);
-                  if (j != num_values - 1)
+                  if (j != default_index)
+                  {
                      strcat(values_buf[i], "|");
+                     strcat(values_buf[i], values[j].value);
+                  }
                }
             }
          }


### PR DESCRIPTION
This PR uses the `default_value` parameter of the new core options interface to 'sanitise' the ordering of numerical core option values.

`libretro_set_core_options()` has been updated to automatically set the correct default value when building old style `retro_variable` arrays for frontends that do not support the new core options interface.