### PR TITLE
Add optional low pass audio filter + gamepad/input improvements

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -163,9 +163,48 @@ struct retro_core_option_definition option_defs_us[] = {
       "enabled"
    },
    {
-      "pokemini_rumblelvl",
-      "Rumble Level (Screen + Controller)",
-      "Specify the magnitude of the force feedback effect, both virtual and physical.",
+      "pokemini_lowpass_filter",
+      "Low Pass Filter",
+      "Enables a low pass audio filter to soften the 'harsh' sound of the Pokemon Mini's piezoelectric speaker.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "pokemini_lowpass_range",
+      "Low Pass Filter Level (%)",
+      "Specifies the cut-off frequency of the low pass audio filter. A higher value increases the perceived 'strength' of the filter, since a wider range of the high frequency spectrum is attenuated.",
+      {
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { "35", NULL },
+         { "40", NULL },
+         { "45", NULL },
+         { "50", NULL },
+         { "55", NULL },
+         { "60", NULL },
+         { "65", NULL },
+         { "70", NULL },
+         { "75", NULL },
+         { "80", NULL },
+         { "85", NULL },
+         { "90", NULL },
+         { "95", NULL },
+         { NULL, NULL },
+      },
+      "60"
+   },
+   {
+      "pokemini_screen_shake_lv",
+      "Screen Shake Level",
+      "Enable virtual force feedback effect by 'shaking' the screen.",
       {
          { "0", NULL },
          { "1", NULL },
@@ -176,26 +215,23 @@ struct retro_core_option_definition option_defs_us[] = {
       "3"
    },
    {
-      "pokemini_controller_rumble",
-      "Controller Rumble",
+      "pokemini_rumble_lv",
+      "Controller Rumble Level",
       "Enable physical force feedback effect via controller rumble.",
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
+         { "0",  NULL },
+         { "1",  NULL },
+         { "2",  NULL },
+         { "3",  NULL },
+         { "4",  NULL },
+         { "5",  NULL },
+         { "6",  NULL },
+         { "7",  NULL },
+         { "8",  NULL },
+         { "9",  NULL },
          { NULL, NULL },
       },
-      "enabled"
-   },
-   {
-      "pokemini_screen_shake",
-      "Screen Shake",
-      "Enable virtual force feedback effect by 'shaking' the screen.",
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL },
-      },
-      "enabled"
+      "9"
    },
    { NULL, NULL, NULL, {{0}}, NULL },
 };

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -126,29 +126,20 @@ struct retro_core_option_definition option_defs_fr[] = {
       NULL
    },
    {
-      "pokemini_rumblelvl",
-      "Niveau de Rumble (écran + contrôleur)",
-      "Spécifiez l'ampleur de l'effet de retour de force, à la fois virtuel et physique.",
+      "pokemini_screen_shake_lv",
+      "Niveau de tremblement de l'écran.",
+      "Activez l'effet de retour de force virtuel en 'secouant' l'écran.",
       {
          { NULL, NULL }, /* Numbers do not require translation */
       },
       NULL
    },
    {
-      "pokemini_controller_rumble",
-      "Contrôleur Rumble",
+      "pokemini_rumble_lv",
+      "Niveau de rumble du contrôleur.",
       "Activer l'effet de retour de force physique via le roulement du contrôleur.",
       {
-         { NULL, NULL }, /* enabled/disabled strings do not require translation */
-      },
-      NULL
-   },
-   {
-      "pokemini_screen_shake",
-      "Secousse de l'écran",
-      "Activez l'effet de retour de force virtuel en 'secouant' l'écran.",
-      {
-         { NULL, NULL }, /* enabled/disabled strings do not require translation */
+         { NULL, NULL }, /* Numbers do not require translation */
       },
       NULL
    },
@@ -269,27 +260,18 @@ struct retro_core_option_definition option_defs_tr[] = {
       NULL
    },
    {
-      "pokemini_rumblelvl",
-      "Rumble Level (Ekran + Kontrolör)",
-      "Hem sanal hem de fiziksel olarak hareketli geri bildirim etkisinin kuvvetini belirtin.",
-      {
-         { NULL, NULL },
-      },
-      NULL
-   },
-   {
-      "pokemini_controller_rumble",
-      "Controller Rumble",
-      "Kontrolör ile fiziksel kuvvet geri bildirim efektini etkinleştirin.",
-      {
-         { NULL, NULL },
-      },
-      NULL
-   },
-   {
-      "pokemini_screen_shake",
-      "Ekran Sarsıntısı",
+      "pokemini_screen_shake_lv",
+      "Ekran Sarsıntı Seviyesi",
       "Ekranı 'sallayarak' sanal güç geribildirim efektini etkinleştirin.",
+      {
+         { NULL, NULL },
+      },
+      NULL
+   },
+   {
+      "pokemini_rumble_lv",
+      "Denetleyici Rumble Seviyesi",
+      "Kontrolör ile fiziksel kuvvet geri bildirim efektini etkinleştirin.",
       {
          { NULL, NULL },
       },

--- a/source/UI.h
+++ b/source/UI.h
@@ -72,9 +72,9 @@ extern TUIMenu_Item UIItems_Options[];			// Options items list
 int UIItems_PlatformDefC(int index, int reason);	// Platform default callback
 extern TUIMenu_Item UIItems_Platform[];			// Platform items list (USER DEFINED)
 
-#define PLATFORMDEF_GOBACK	{ 0,  0, "Go back...", UIItems_PlatformDefC }
-#define PLATFORMDEF_SAVEOPTIONS	{ 0, 99, "Save Configs...", UIItems_PlatformDefC }
-#define PLATFORMDEF_END(cb)	{ 9,  0, "Platform", cb }
+#define PLATFORMDEF_GOBACK	{ 0,  0, "Go back...", UIItems_PlatformDefC, NULL }
+#define PLATFORMDEF_SAVEOPTIONS	{ 0, 99, "Save Configs...", UIItems_PlatformDefC, NULL }
+#define PLATFORMDEF_END(cb)	{ 9,  0, "Platform", cb, NULL }
 
 // UI return status
 //  1 = In Menu


### PR DESCRIPTION
This PR makes the following improvements to the core:

- An optional low pass audio filter has been added. The Pokemon Mini's piezoelectric speaker produces quite 'harsh' sounding audio - on a real console this is muffled somewhat by the plastic casing, but when emulated it can be too sharp. Enabling the new `Low Pass Filter` option can make the sound more comfortable.

- Input bitmasks are now supported

- The efficiency of the gamepad rumble routines has been improved - `set_rumble_state()` is now only called when the rumble strength changes

- The gamepad rumble strength can now be set independently from the screen shake level

- A `Turbo A` button has been added (mapped by default to RetroPad X). This is mostly for use with the game 'Pokémon Zany Cards', which otherwise requires some of the most mind numbing button mashing I have ever experienced (the console has few enough games that per-title 'optimisations' are worthwhile)