### PR TITLE
Add RS-90 build target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,6 +219,12 @@ libretro-build-dingux-odbeta-mips32:
     - .libretro-dingux-odbeta-mips32-make-default
     - .core-defs
 
+# RS-90 OpenDingux Beta
+libretro-build-rs90-odbeta-mips32:
+  extends:
+    - .libretro-rs90-odbeta-mips32-make-default
+    - .core-defs
+
 # Nintendo 3DS
 libretro-build-ctr:
   extends:

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -434,6 +434,18 @@ else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_emscripten.$(EXT)
 	STATIC_LINKING=1
 
+# RS90
+else ifeq ($(platform), rs90)
+	TARGET := $(TARGET_NAME)_libretro.so
+	CC = /opt/rs90-toolchain/usr/bin/mipsel-linux-gcc
+	CXX = /opt/rs90-toolchain/usr/bin/mipsel-linux-g++
+	AR = /opt/rs90-toolchain/usr/bin/mipsel-linux-ar
+	SHARED := -shared -Wl,--version-script=libretro/link.T
+	fpic := -fPIC
+	CFLAGS += $(PTHREAD_FLAGS)
+	CFLAGS += -ffast-math -fomit-frame-pointer -march=mips32 -mtune=mips32
+	CFLAGS += -DDINGUX -DRS90
+
 # GCW0
 else ifeq ($(platform), gcw0)
 	TARGET := $(TARGET_NAME)_libretro.so

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -428,7 +428,7 @@ static void InitialiseCommandLine(const struct retro_game_info *game)
 	
 #if defined(_3DS)
 	// 3DS has limited performance...
-	// > Lower emualtion accuacy if required (o3DS/o2DS)
+	// > Lower emulation accuracy if required (o3DS/o2DS)
 	CFGU_GetSystemModel(&device_model); /* (0 = O3DS, 1 = O3DSXL, 2 = N3DS, 3 = 2DS, 4 = N3DSXL, 5 = N2DSXL) */
 	if (device_model == 2 || device_model == 4 || device_model == 5) {
 		CommandLine.synccycles = 8;
@@ -437,9 +437,17 @@ static void InitialiseCommandLine(const struct retro_game_info *game)
 	}
 	// > Reduce sound quality
 	CommandLine.sound = MINX_AUDIO_GENERATED;
+#elif defined(RS90)
+	// RS-90 devices running OpenDingux appear
+	// to have similar performance to o3DS
+	// > Lower emulation accuracy and reduce
+	//   sound quality
+	CommandLine.synccycles = 16;
+	CommandLine.sound = MINX_AUDIO_GENERATED;
 #elif defined(DINGUX)
-	// Dingux platforms appear to have similar
-	// performance to n3DS when running this core
+	// Other OpenDingux platforms appear to have
+	// similar performance to n3DS when running
+	// this core
 	// > Use default 'accurate' emulation,
 	//   but reduce sound quality
 	CommandLine.synccycles = 8;


### PR DESCRIPTION
This PR adds a Makefile + gitlab-ci.yml target for RS-90 devices.

The core is currently untested on this platform, but given the performance of other cores I would expect it to run at full speed.

@john-parton Would you be willing to test this core?