### PR TITLE
Add 7x (672x448) video scale

### DIFF
--- a/build/Makefile.common
+++ b/build/Makefile.common
@@ -38,6 +38,7 @@ SOURCES_C := \
 	$(CORE_DIR)/source/Video_x4.c \
 	$(CORE_DIR)/source/Video_x5.c \
 	$(CORE_DIR)/source/Video_x6.c \
+	$(CORE_DIR)/source/Video_x7.c \
 	$(CORE_DIR)/source/Video.c \
 	$(CORE_DIR)/resource/PokeMini_ColorPal.c \
 	$(CORE_DIR)/libretro/libretro.c

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -31,6 +31,7 @@
 #include "Video_x4.h"
 #include "Video_x5.h"
 #include "Video_x6.h"
+#include "Video_x7.h"
 
 #ifdef _3DS
 void* linearMemAlign(size_t size, size_t alignment);
@@ -614,6 +615,10 @@ static void InitialiseVideo(void)
 		{
 			video_scale = 6;
 		}
+		else if (strcmp(variables.value, "7x") == 0)
+		{
+			video_scale = 7;
+		}
 #endif
 	}
 
@@ -661,6 +666,9 @@ static void InitialiseVideo(void)
 			break;
 		case 6:
 			video_spec = (TPokeMini_VideoSpec *)&PokeMini_Video6x6;
+			break;
+		case 7:
+			video_spec = (TPokeMini_VideoSpec *)&PokeMini_Video7x7;
 			break;
 		default: // video_scale == 1
 			video_spec = (TPokeMini_VideoSpec *)&PokeMini_Video1x1;

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -61,6 +61,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "4x", NULL },
          { "5x", NULL },
          { "6x", NULL },
+         { "7x", NULL },
 #endif
          { NULL, NULL },
       },

--- a/source/Video_x7.c
+++ b/source/Video_x7.c
@@ -1,0 +1,1487 @@
+/*
+  PokeMini - Pokémon-Mini Emulator
+  Copyright (C) 2009-2012  JustBurn
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PokeMini.h"
+#include "Video_x7.h"
+
+const TPokeMini_VideoSpec PokeMini_Video7x7 = {
+	7, 7,
+	PokeMini_GetVideo7x7_16,
+	PokeMini_GetVideo7x7_32
+};
+
+const int LCDMask7x7[7*7] = {
+	240, 256, 256, 256, 256, 240, 128,
+	256, 256, 256, 256, 256, 256, 160,
+	256, 256, 256, 256, 256, 256, 160,
+	256, 256, 256, 256, 256, 256, 160,
+	256, 256, 256, 256, 256, 256, 160,
+	240, 256, 256, 256, 256, 240, 192,
+	128, 160, 160, 160, 160, 192, 160
+};
+
+TPokeMini_DrawVideo32 PokeMini_GetVideo7x7_32(int filter, int lcdmode)
+{
+	if (filter == PokeMini_Scanline) {
+		switch (lcdmode) {
+			case 3: return PokeMini_VideoColorL7x7_32;
+			case 2: return PokeMini_Video2ScanLine7x7_32;
+			case 1: return PokeMini_Video3ScanLine7x7_32;
+			default: return PokeMini_VideoAScanLine7x7_32;
+		}
+	} else if (filter == PokeMini_Matrix) {
+		switch (lcdmode) {
+			case 3: return (VidEnableHighcolor) ? PokeMini_VideoColorH7x7_32 : PokeMini_VideoColor7x7_32;
+			case 2: return PokeMini_Video2Matrix7x7_32;
+			case 1: return PokeMini_Video3Matrix7x7_32;
+			default: return PokeMini_VideoAMatrix7x7_32;
+		}
+	} else {
+		switch (lcdmode) {
+			case 3: return PokeMini_VideoColor7x7_32;
+			case 2: return PokeMini_Video2None7x7_32;
+			case 1: return PokeMini_Video3None7x7_32;
+			default: return PokeMini_VideoANone7x7_32;
+		}
+	}
+}
+
+TPokeMini_DrawVideo16 PokeMini_GetVideo7x7_16(int filter, int lcdmode)
+{
+	if (filter == PokeMini_Scanline) {
+		switch (lcdmode) {
+			case 3: return PokeMini_VideoColorL7x7_16;
+			case 2: return PokeMini_Video2ScanLine7x7_16;
+			case 1: return PokeMini_Video3ScanLine7x7_16;
+			default: return PokeMini_VideoAScanLine7x7_16;
+		}
+	} else if (filter == PokeMini_Matrix) {
+		switch (lcdmode) {
+			case 3: return (VidEnableHighcolor) ? PokeMini_VideoColorH7x7_16 : PokeMini_VideoColor7x7_16;
+			case 2: return PokeMini_Video2Matrix7x7_16;
+			case 1: return PokeMini_Video3Matrix7x7_16;
+			default: return PokeMini_VideoAMatrix7x7_16;
+		}
+	} else {
+		switch (lcdmode) {
+			case 3: return PokeMini_VideoColor7x7_16;
+			case 2: return PokeMini_Video2None7x7_16;
+			case 1: return PokeMini_Video3None7x7_16;
+			default: return PokeMini_VideoANone7x7_16;
+		}
+	}
+}
+
+void PokeMini_VideoAScanLine7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint32_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<32; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_VideoAScanLine7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint16_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<32; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_Video3ScanLine7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint32_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<32; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_Video3ScanLine7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint16_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<32; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_Video2ScanLine7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint32_t *ptr, pix, pix1, pix0;
+
+	LCDY = 0;
+	pix1 = VidPalette32[MinxLCD.Pixel1Intensity];
+	pix0 = VidPalette32[MinxLCD.Pixel0Intensity];
+	for (yk=0; yk<32; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_Video2ScanLine7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint16_t *ptr, pix, pix1, pix0;
+
+	LCDY = 0;
+	pix1 = VidPalette16[MinxLCD.Pixel1Intensity];
+	pix0 = VidPalette16[MinxLCD.Pixel0Intensity];
+	for (yk=0; yk<32; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_VideoAMatrix7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, level, LCDY, maskH;
+	uint32_t *ptr;
+
+	LCDY = 0;
+	maskH = 0;
+	for (yk=0; yk<64*7; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			level = LCDPixelsA[LCDY + xk];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+1] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+2] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+3] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+4] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+5] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+6] >> 8];
+		}
+		screen += pitchW;
+		maskH += 7;
+		if (maskH >= 49) {
+			maskH = 0;
+			LCDY += 96;
+		}
+	}
+}
+
+void PokeMini_VideoAMatrix7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, level, LCDY, maskH;
+	uint16_t *ptr;
+
+	LCDY = 0;
+	maskH = 0;
+	for (yk=0; yk<64*7; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			level = LCDPixelsA[LCDY + xk];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+1] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+2] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+3] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+4] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+5] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+6] >> 8];
+		}
+		screen += pitchW;
+		maskH += 7;
+		if (maskH >= 49) {
+			maskH = 0;
+			LCDY += 96;
+		}
+	}
+}
+
+void PokeMini_Video3Matrix7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, level, LCDY, maskH;
+	uint32_t *ptr;
+
+	LCDY = 0;
+	maskH = 0;
+	for (yk=0; yk<64*7; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: level = MinxLCD.Pixel1Intensity; break;
+				case 1: level = (MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1; break;
+				default: level = MinxLCD.Pixel0Intensity; break;
+			}
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+1] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+2] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+3] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+4] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+5] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+6] >> 8];
+		}
+		screen += pitchW;
+		maskH += 7;
+		if (maskH >= 49) {
+			maskH = 0;
+			LCDY += 96;
+		}
+	}
+}
+
+void PokeMini_Video3Matrix7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, level, LCDY, maskH;
+	uint16_t *ptr;
+
+	LCDY = 0;
+	maskH = 0;
+	for (yk=0; yk<64*7; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: level = MinxLCD.Pixel1Intensity; break;
+				case 1: level = (MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1; break;
+				default: level = MinxLCD.Pixel0Intensity; break;
+			}
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+1] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+2] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+3] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+4] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+5] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+6] >> 8];
+		}
+		screen += pitchW;
+		maskH += 7;
+		if (maskH >= 49) {
+			maskH = 0;
+			LCDY += 96;
+		}
+	}
+}
+
+void PokeMini_Video2Matrix7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, level, LCDY, maskH;
+	uint32_t *ptr;
+
+	LCDY = 0;
+	maskH = 0;
+	for (yk=0; yk<64*7; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) level = MinxLCD.Pixel1Intensity;
+			else level = MinxLCD.Pixel0Intensity;
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+1] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+2] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+3] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+4] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+5] >> 8];
+			*ptr++ = VidPalette32[level * LCDMask7x7[maskH+6] >> 8];
+		}
+		screen += pitchW;
+		maskH += 7;
+		if (maskH >= 49) {
+			maskH = 0;
+			LCDY += 96;
+		}
+	}
+}
+
+void PokeMini_Video2Matrix7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, level, LCDY, maskH;
+	uint16_t *ptr;
+
+	LCDY = 0;
+	maskH = 0;
+	for (yk=0; yk<64*7; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) level = MinxLCD.Pixel1Intensity;
+			else level = MinxLCD.Pixel0Intensity;
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+1] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+2] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+3] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+4] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+5] >> 8];
+			*ptr++ = VidPalette16[level * LCDMask7x7[maskH+6] >> 8];
+		}
+		screen += pitchW;
+		maskH += 7;
+		if (maskH >= 49) {
+			maskH = 0;
+			LCDY += 96;
+		}
+	}
+}
+
+void PokeMini_VideoANone7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint32_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette32[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_VideoANone7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint16_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalette16[LCDPixelsA[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_Video3None7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint32_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette32[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette32[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette32[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_Video3None7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint16_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			switch (LCDPixelsD[LCDY + xk] + LCDPixelsA[LCDY + xk]) {
+				case 2: pix = VidPalette16[MinxLCD.Pixel1Intensity]; break;
+				case 1: pix = VidPalette16[(MinxLCD.Pixel0Intensity + MinxLCD.Pixel1Intensity) >> 1]; break;
+				default: pix = VidPalette16[MinxLCD.Pixel0Intensity]; break;
+			}
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_Video2None7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint32_t *ptr, pix, pix1, pix0;
+
+	LCDY = 0;
+	pix1 = VidPalette32[MinxLCD.Pixel1Intensity];
+	pix0 = VidPalette32[MinxLCD.Pixel0Intensity];
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_Video2None7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint16_t *ptr, pix, pix1, pix0;
+
+	LCDY = 0;
+	pix1 = VidPalette16[MinxLCD.Pixel1Intensity];
+	pix0 = VidPalette16[MinxLCD.Pixel0Intensity];
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			if (LCDPixelsD[LCDY + xk]) pix = pix1;
+			else pix = pix0;
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_VideoColor7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint32_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_VideoColor7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint16_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_VideoColorL7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint32_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<32; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor32[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*4);
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_VideoColorL7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint16_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<32; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColor16[PRCColorPixels[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		memset(screen, 0, 672*2);
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_VideoColorH7x7_32(uint32_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint32_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH32[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH32[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH32[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH32[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH32[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH32[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH32[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}
+
+void PokeMini_VideoColorH7x7_16(uint16_t *screen, int pitchW)
+{
+	int xk, yk, LCDY;
+	uint16_t *ptr, pix;
+
+	LCDY = 0;
+	for (yk=0; yk<64; yk++) {
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH16[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH16[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH16[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH16[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH16[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH16[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		ptr = screen;
+		for (xk=0; xk<96; xk++) {
+			pix = VidPalColorH16[PRCColorPixels[LCDY + xk] * 256 + PRCColorPixelsOld[LCDY + xk]];
+			*ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix; *ptr++ = pix;
+		}
+		screen += pitchW;
+		LCDY += 96;
+	}
+}

--- a/source/Video_x7.h
+++ b/source/Video_x7.h
@@ -1,0 +1,75 @@
+/*
+  PokeMini - Pokémon-Mini Emulator
+  Copyright (C) 2009-2012  JustBurn
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef POKEMINI_VIDEO_X7
+#define POKEMINI_VIDEO_X7
+
+#include <stdint.h>
+
+// Video specs
+extern const TPokeMini_VideoSpec PokeMini_Video7x7;
+
+// Return the best blitter
+TPokeMini_DrawVideo32 PokeMini_GetVideo7x7_32(int filter, int lcdmode);
+TPokeMini_DrawVideo16 PokeMini_GetVideo7x7_16(int filter, int lcdmode);
+
+// Render to 672x448, analog + scanline
+void PokeMini_VideoAScanLine7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_VideoAScanLine7x7_16(uint16_t *screen, int pitchW);
+
+// Render to 672x448, 3-colors + scanline
+void PokeMini_Video3ScanLine7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_Video3ScanLine7x7_16(uint16_t *screen, int pitchW);
+
+// Render to 672x448, 2-colors + scanline
+void PokeMini_Video2ScanLine7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_Video2ScanLine7x7_16(uint16_t *screen, int pitchW);
+
+// Render to 672x448, analog + dot matrix
+void PokeMini_VideoAMatrix7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_VideoAMatrix7x7_16(uint16_t *screen, int pitchW);
+
+// Render to 672x448, 3-colors + dot matrix
+void PokeMini_Video3Matrix7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_Video3Matrix7x7_16(uint16_t *screen, int pitchW);
+
+// Render to 672x448, 2-colors + dot matrix
+void PokeMini_Video2Matrix7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_Video2Matrix7x7_16(uint16_t *screen, int pitchW);
+
+// Render to 672x448, analog
+void PokeMini_VideoANone7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_VideoANone7x7_16(uint16_t *screen, int pitchW);
+
+// Render to 672x448, 3-colors
+void PokeMini_Video3None7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_Video3None7x7_16(uint16_t *screen, int pitchW);
+
+// Render to 672x448, 2-colors
+void PokeMini_Video2None7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_Video2None7x7_16(uint16_t *screen, int pitchW);
+
+// Render to 672x448, unofficial colors
+void PokeMini_VideoColor7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_VideoColor7x7_16(uint16_t *screen, int pitchW);
+void PokeMini_VideoColorL7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_VideoColorL7x7_16(uint16_t *screen, int pitchW);
+void PokeMini_VideoColorH7x7_32(uint32_t *screen, int pitchW);
+void PokeMini_VideoColorH7x7_16(uint16_t *screen, int pitchW);
+
+#endif


### PR DESCRIPTION
In theory, there's no end to how high you could go adding more scale factors, but stopping at 6x seemed one short to me, so here's 7x. This takes the resolution to 448 lines, making it particularly well-suited to widescreen 480p displays like the many retro handhelds or the Wii U GamePad. Because 7 is such an awkward number, there was no decent way to fill a 480p screen, so now there is.

Incidentally, the scaling setup here is not all that it could be. There's *tons* of code duplication, each scaler function is basically just the same code pasted *n* times. While I know enough to spot that that's not best practice, I'll leave it to somebody who knows what they're doing to improve on it.