### PR TITLE
Add optional 60Hz mode

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -72,6 +72,17 @@ struct retro_core_option_definition option_defs_us[] = {
 #endif
    },
    {
+      "pokemini_60hz_mode",
+      "60Hz Mode",
+      "Update the display at 60Hz instead of the native 72Hz Pokemon Mini's refresh rate by dropping every sixth frame. Reduces video smoothness, but avoids screen tearing on displays that do not support native operation above 60Hz.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled",
+   },
+   {
       "pokemini_lcdfilter",
       "LCD Filter",
       "Select internal screen filter. 'Dot Matrix' produces an LCD effect that mimics real hardware. LCD filters are disabled when 'Video Scale' is set to '1x'.",


### PR DESCRIPTION
At present the core runs at 72Hz, matching the native refresh rate of the Pokemon Mini hardware. This is fine if the core is run on a VRR display (or one that natively supports 72Hz...), but on regular 60Hz panels it can cause issues. In particular, screen tearing is very likely to occur. I experience this on Linux (when not using a compositor and without vsync forced at the driver level) and on 3DS.

This PR adds a new `60Hz Mode` core option (enabled by default), which can be used to force the core to run at 60Hz. Note that the core still runs at the 'correct' speed when this option is enabled - internally, the core is running the nominal 72 frames per second, but every 6th frame is 'dropped'. This reduces video smoothness, but then 72Hz on a 60Hz display is not smooth either (and few Pokemon Mini games are 'smooth' to begin with...). More importantly, enabling this option eliminates screen tearing.