### PR TITLE
Fix some savestates issues

### DIFF
--- a/source/MinxColorPRC.c
+++ b/source/MinxColorPRC.c
@@ -89,9 +89,9 @@ int MinxColorPRC_LoadStateStream(memstream_t *stream, uint32_t bsize)
 	POKELOADSS_STREAM_8(MinxColorPRC.LNColor1);
 	POKELOADSS_STREAM_8(MinxColorPRC.HNColor1);
 	POKELOADSS_STREAM_X(20);
-	POKELOADSS_END(16384+32);
 	MinxColorPRC.Address &= 0x3FFF;
 	PRCColorPixels = PRCColorVMem + (MinxColorPRC.ActivePage ? 0x2000 : 0);
+	POKELOADSS_END(16384+32);
 }
 
 int MinxColorPRC_SaveStateStream(memstream_t *stream)

--- a/source/MinxLCD.c
+++ b/source/MinxLCD.c
@@ -108,7 +108,6 @@ int MinxLCD_LoadStateStream(memstream_t *stream, uint32_t bsize)
 	POKELOADSS_STREAM_8(MinxLCD.RMWColumn);
 	POKELOADSS_STREAM_X(42);
 	POKELOADSS_END(256*9 + 96*64 + 96*64 + 64);
-	return 1;
 }
 
 int MinxLCD_SaveStateStream(memstream_t *stream)

--- a/source/MinxTimers.c
+++ b/source/MinxTimers.c
@@ -127,7 +127,6 @@ int MinxTimers_LoadStateStream(memstream_t *stream, uint32_t bsize)
 	POKELOADSS_STREAM_8(MinxTimers.TmrXEna2);
 	POKELOADSS_STREAM_8(MinxTimers.TmrXEna1);
 	POKELOADSS_STREAM_X(34);
-	POKELOADSS_END(128);
 	MinxTimers.Tmr1WMode = PMR_TMR1_CTRL_L & 0x80;
 	MinxTimers.Tmr1LEna = PMR_TMR1_CTRL_L & 0x04;
 	MinxTimers.Tmr1HEna = PMR_TMR1_CTRL_H & 0x04;
@@ -137,6 +136,7 @@ int MinxTimers_LoadStateStream(memstream_t *stream, uint32_t bsize)
 	MinxTimers.Tmr3WMode = PMR_TMR3_CTRL_L & 0x80;
 	MinxTimers.Tmr3LEna = PMR_TMR3_CTRL_L & 0x04;
 	MinxTimers.Tmr3HEna = PMR_TMR3_CTRL_H & 0x04;
+	POKELOADSS_END(128);
 }
 
 int MinxTimers_SaveStateStream(memstream_t *stream)

--- a/source/PokeMini.c
+++ b/source/PokeMini.c
@@ -404,7 +404,7 @@ int PokeMini_LoadSSStream(uint8_t *buffer, uint64_t size)
 				memstream_set_buffer(NULL, 0);
 				return 0;
 			}
-		} else if (!strcmp(PMiniStr, "LCD-")) {		// Audio
+		} else if (!strcmp(PMiniStr, "AUD-")) {		// Audio
 			if (!MinxAudio_LoadStateStream(stream, BSize)) {
 				memstream_close(stream);
 				memstream_set_buffer(NULL, 0);


### PR DESCRIPTION
This PR is fixing 2 issues with save states :
- A typo in read save state function was causing audio data not to be restored.
- Some code was sometimes added after the POKELOADSS_END() macro. As POKELOADSS_END is performing a return, all code after it is ignored.